### PR TITLE
Add an initial Dockerfile 🙃

### DIFF
--- a/.tekton/ko-builder-pull-request.yaml
+++ b/.tekton/ko-builder-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: .
+    value: Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/ko-builder-push.yaml
+++ b/.tekton/ko-builder-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/konflux-build-pipeli-tenant/ko-builder:{{revision}}
   - name: dockerfile
-    value: .
+    value: Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.redhat.io/ubi9/go-toolset@sha256:c7bfd2501cb1be171366434a368db669b32f08a0198c1473b9bff0a379613fc3 AS builder
+ARG KO_VERSION=v0.17.1
+RUN GOBIN=/tmp go install github.com/google/ko@${KO_VERSION}
+
+FROM registry.redhat.io/ubi9/go-toolset@sha256:c7bfd2501cb1be171366434a368db669b32f08a0198c1473b9bff0a379613fc3
+COPY --from=builder /tmp/ko /usr/bin/ko
+ENTRYPOINT ["/usr/bin/ko"]
+
+LABEL org.opencontainers.image.description="konflux ubi based ko builder image"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - vdemeester
+  - arewm
+  - ggallen


### PR DESCRIPTION
This is using `ubi9/go-toolset` as base. This is using multi-stage to
reduce layers size (not shipping go caches used to build the `ko` binary).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
